### PR TITLE
Update Makefile and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,23 @@
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Docker build usage:
 # 	docker build . -t opensdsio/dashboard:latest
 # Docker run usage:
 # 	docker run -d -p 8088:8088 opensdsio/dashboard:latest
 
-FROM ubuntu:16.04
+FROM node:8.12.0
 MAINTAINER Leon Wang <wanghui71leon@gmail.com>
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -11,15 +25,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Download and install some packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   sudo \
-  wget \
-  make \
   g++ \
   nginx \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
-RUN wget --no-check-certificate https://deb.nodesource.com/setup_8.x \
-  && chmod +x setup_8.x && ./setup_8.x \
-  && apt-get install -y nodejs
 
 # Current directory is always /opt/dashboard.
 WORKDIR /opt/dashboard
@@ -29,7 +38,6 @@ COPY ./ ./
 
 RUN chmod 755 ./image_builder.sh \
   && sudo ./image_builder.sh
-RUN sudo ./image_builder.sh --rebuild
 
 # Define default command.
 CMD /usr/sbin/nginx -g "daemon off;"

--- a/Makefile
+++ b/Makefile
@@ -21,23 +21,10 @@ all:build
 build:dashboard
 .PHONY: build
 
-dashboard:package
+dashboard:
 	chmod +x ./image_builder.sh \
 	  && ./image_builder.sh
 .PHONY: dashboard
-
-package:
-	apt-get update && apt-get install -y --no-install-recommends \
-	  wget \
-	  make \
-	  g++ \
-	  nginx \
-	  && rm -rf /var/lib/apt/lists/* \
-	  && apt-get clean
-	wget --no-check-certificate https://deb.nodesource.com/setup_8.x \
-	  && chmod +x setup_8.x && ./setup_8.x \
-	  && apt-get install -y nodejs
-.PHONY: package
 
 docker:
 	docker build . -t $(IMAGE):$(VERSION)
@@ -48,6 +35,4 @@ clean:
 	rm -rf /etc/nginx/sites-available/default /var/www/html/* ./dist warn=False
 	npm uninstall --unsafe-perm
 	npm uninstall --unsafe-perm -g @angular/cli@1.7.4
-	apt-get --purge remove -y nodejs nginx \
-	  && rm -rf ./setup_8.x warn=False
 .PHONY: clean


### PR DESCRIPTION
To reduce the complexity of Dockerfile, I updated the base image to `node:8.12.0` so we don't need to install nodejs manually.

Besides, I also updated `Makefile` to fix some issues pulled by @stmcginnis .