### PR TITLE
add parameters LISTEN_PORT ,OPENSDS_HOST_IP for dashborad image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ node_js:
 
 before_script:
    - "sudo apt-get update && sudo apt-get install -y nginx make"
-   - npm install -g @angular/cli@1.7.4
 
 script: # the build step
-   - sudo make
+   - make
 
 after_script:
-   - sudo make clean
+   - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 
 before_script:
    - "sudo apt-get update && sudo apt-get install -y nginx make"
+   - npm install -g @angular/cli@1.7.4
 
 script: # the build step
    - sudo make

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ WORKDIR /opt/dashboard
 
 # Copy dashboard source code into container before running command.
 COPY ./ ./
-
 RUN chmod 755 ./image_builder.sh \
   && sudo ./image_builder.sh
 
+COPY entrypoint.sh ./
 # Define default command.
-CMD /usr/sbin/nginx -g "daemon off;"
+ENTRYPOINT /opt/dashboard/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OPENSDS_HOST_IP=${OPENSDS_HOST_IP:-127.0.0.1}
+LISTEN_PORT=${LISTEN_PORT:-8088}
+cat > /etc/nginx/sites-available/default <<EOF
+    server {
+        listen $LISTEN_PORT default_server;
+        listen [::]:$LISTEN_PORT default_server;
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
+        server_name _;
+        location /v3/ {
+            proxy_pass http://$OPENSDS_HOST_IP/identity/v3/;
+        }
+
+        location /v1beta/ {
+            proxy_pass http://$OPENSDS_HOST_IP:50040/v1beta/;
+        }
+
+        location /v1/ {
+            proxy_pass http://$OPENSDS_HOST_IP:8089/v1/;
+            client_max_body_size 10240m;
+        }
+    }
+EOF
+
+/usr/sbin/nginx -g "daemon off;"
+
+

--- a/image_builder.sh
+++ b/image_builder.sh
@@ -22,5 +22,6 @@ npm install --unsafe-perm -g @angular/cli@1.7.4
 npm install --unsafe-perm
 ng build --prod
 
+mkdir /var/www/html/ -p
 cp -R ./dist/* /var/www/html/
 

--- a/image_builder.sh
+++ b/image_builder.sh
@@ -24,24 +24,3 @@ ng build --prod
 
 cp -R ./dist/* /var/www/html/
 
-cat > /etc/nginx/sites-available/default <<EOF
-    server {
-        listen 8088 default_server;
-        listen [::]:8088 default_server;
-        root /var/www/html;
-        index index.html index.htm index.nginx-debian.html;
-        server_name _;
-        location /v3/ {
-            proxy_pass http://127.0.0.1/identity/v3/;
-        }
-
-        location /v1beta/ {
-            proxy_pass http://127.0.0.1:50040/v1beta/;
-        }
-
-        location /v1/ {
-            proxy_pass http://127.0.0.1:8089/v1/;
-            client_max_body_size 10240m;
-        }
-    }
-EOF

--- a/image_builder.sh
+++ b/image_builder.sh
@@ -22,6 +22,6 @@ npm install --unsafe-perm -g @angular/cli@1.7.4
 npm install --unsafe-perm
 ng build --prod
 
-mkdir /var/www/html/ -p
-cp -R ./dist/* /var/www/html/
+sudo mkdir /var/www/html/ -p
+sudo cp -R ./dist/* /var/www/html/
 


### PR DESCRIPTION
Add parameters LISTEN_PORT ,OPENSDS_HOST_IP for dashborad image, so user can add EVNs to specified which port or host_ip to be used. 
such as:
```
docker run -d --network=host -e LISTEN_PORT=8888 -e OPENSDS_HOST_IP=45.77.125.119 opensdsio/dashboard:latest
```