### PR TITLE
Fixed project name. changed primeng to opensds-dashboard

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "project": {
-    "name": "primeng"
+    "name": "opensds-dashboard"
   },
   "apps": [
     {


### PR DESCRIPTION
The project name in the .angular-cli.json file was incorrectly mentioned as `primeng`.  
Fixed it by changing it to the correct project name  `opensds-dashboard`