### PR TITLE
Fixed #92. Url links in the Monitor list page not working.

### DIFF
--- a/src/app/business/monitor/monitor-list/monitor-list.component.html
+++ b/src/app/business/monitor/monitor-list/monitor-list.component.html
@@ -20,7 +20,7 @@
                 </p-header>
                 <div>{{item.description}}</div>
                 <p-footer>
-                  <a href="{{item.URL}}" target="_blank"><button pButton type="button" label="View Dashboard" icon="fa-external-link" class="ui-button-secondary"></button></a>
+                  <a href="{{item.url}}" target="_blank"><button pButton type="button" label="View Dashboard" icon="fa-external-link" class="ui-button-secondary"></button></a>
                 </p-footer>
             </p-card>
         </div>


### PR DESCRIPTION
Fixes #92 
The key for the dashboard urls in the urls api was changed from `URL` to `url`