### PR TITLE
Fixes #214. User can select the host from available list in volume provision service

### DIFF
--- a/src/app/business/services/dynamic-form/dynamic-form.component.html
+++ b/src/app/business/services/dynamic-form/dynamic-form.component.html
@@ -53,8 +53,8 @@
 
             <div class="form-item-container" *ngSwitchCase="'select'">
                 <form-item label="{{prop.label}}" [required]="true">
-                    <p-dropdown [disabled]="noHosts && (prop.key == 'host_info')" [options]="prop.options" [required]="true" [formControlName]="prop.key" [placeholder]="prop.description ? prop.description : ''"></p-dropdown>
-                    <div *ngIf="noHosts && (prop.key == 'host_info')">
+                    <p-dropdown [disabled]="noHosts && (prop.key == 'host_id')" [options]="prop.options" [required]="true" [formControlName]="prop.key" [placeholder]="prop.description ? prop.description : ''"></p-dropdown>
+                    <div *ngIf="noHosts && (prop.key == 'host_id')">
                         <i class="fa fa-exclamation-circle fa-2x"></i>
                         <span >There are no hosts. Would you like to add one? </span>
                         <a  [routerLink]="['/createHost']">Add Host</a>

--- a/src/app/business/services/dynamic-form/dynamic-form.component.html
+++ b/src/app/business/services/dynamic-form/dynamic-form.component.html
@@ -53,7 +53,12 @@
 
             <div class="form-item-container" *ngSwitchCase="'select'">
                 <form-item label="{{prop.label}}" [required]="true">
-                    <p-dropdown [options]="prop.options" [required]="true" [formControlName]="prop.key" [placeholder]="prop.description ? prop.description : ''"></p-dropdown>
+                    <p-dropdown [disabled]="noHosts && (prop.key == 'host_info')" [options]="prop.options" [required]="true" [formControlName]="prop.key" [placeholder]="prop.description ? prop.description : ''"></p-dropdown>
+                    <div *ngIf="noHosts && (prop.key == 'host_info')">
+                        <i class="fa fa-exclamation-circle fa-2x"></i>
+                        <span >There are no hosts. Would you like to add one? </span>
+                        <a  [routerLink]="['/createHost']">Add Host</a>
+                    </div>
                 </form-item>      
             </div>
           </div>

--- a/src/app/business/services/dynamic-form/dynamic-form.component.html
+++ b/src/app/business/services/dynamic-form/dynamic-form.component.html
@@ -54,6 +54,11 @@
             <div class="form-item-container" *ngSwitchCase="'select'">
                 <form-item label="{{prop.label}}" [required]="true">
                     <p-dropdown [disabled]="noHosts && (prop.key == 'host_id')" [options]="prop.options" [required]="true" [formControlName]="prop.key" [placeholder]="prop.description ? prop.description : ''"></p-dropdown>
+                    <div *ngIf="(prop.key == 'host_id')">
+                        <i class="fa fa-exclamation-circle fa-2x"></i>
+                        <span >Would you like to add a host? </span>
+                        <a  [routerLink]="['/createHost']">Add Host</a>
+                    </div>
                     <div *ngIf="noHosts && (prop.key == 'host_id')">
                         <i class="fa fa-exclamation-circle fa-2x"></i>
                         <span >There are no hosts. Would you like to add one? </span>

--- a/src/app/business/services/dynamic-form/dynamic-form.component.ts
+++ b/src/app/business/services/dynamic-form/dynamic-form.component.ts
@@ -182,8 +182,7 @@ export class DynamicFormComponent implements OnInit {
     getAllHosts(){
       let self = this;
         this.HostsService.getHosts().subscribe((res) => {
-          console.log("All Hosts Dummy", res.json().allHosts);
-            this.allHosts = res.json().allHosts;
+          this.allHosts = res.json();
             if(this.allHosts.length == 0){
               this.noHosts = true;
             }

--- a/src/app/business/services/services.module.ts
+++ b/src/app/business/services/services.module.ts
@@ -19,6 +19,7 @@ import { CreateInstanceComponent } from './create-instance/create-instance.compo
 import { CreateClusterComponent } from './create-cluster/create-cluster.component';
 import { WorkflowService } from './workflow.service';
 import { ProfileService } from '../profile/profile.service';
+import { HostsService } from '../block/hosts.service';
 import { HttpClientModule } from '@angular/common/http';
 import { DynamicFormComponent } from './dynamic-form/dynamic-form.component';
 
@@ -57,6 +58,6 @@ import { DynamicFormComponent } from './dynamic-form/dynamic-form.component';
     HttpClientModule,
     SpinnerModule],
   exports: [ServicesRoutingModule],
-  providers: [WorkflowService, ProfileService, ConfirmationService]
+  providers: [WorkflowService, ProfileService, HostsService, ConfirmationService]
 })
 export class ServicesModule { }


### PR DESCRIPTION
**Depends on [opensds/orchestration #99](https://github.com/opensds/orchestration/pull/99)**  
**Do not merge this without merging above**
After Host management has been introduced, user can select a host to attach to a volume in the volume provision orchestration service instead of entering the Host Info.

Select Host 
![select-host](https://user-images.githubusercontent.com/19162717/69478285-b5c6de80-0e16-11ea-8173-3ec810325d5a.png)

Prompt user to add a host if no host available 
![no-hosts](https://user-images.githubusercontent.com/19162717/69478290-c0817380-0e16-11ea-8d9f-79dd244f73c9.png)

