### PR TITLE
[FEATURE] Fixes #215. Added display object version in a bucket.

### DIFF
--- a/src/app/business/block/bucket-detail/bucket-detail.component.html
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.html
@@ -23,7 +23,8 @@
                         <button class="" pButton type="button" (click)="getAlldir()" icon="fa-refresh"></button>
                     </div>
                 </div>
-                <p-dataTable [value]="allDir" [globalFilter]="searchByName" [(selection)]="selectedDir"  [showHeaderCheckbox]="true" resizableColumns="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]">
+                <p-dataTable [value]="allDir" [globalFilter]="searchByName" expandableRows="true" [(selection)]="selectedDir"  [showHeaderCheckbox]="true" resizableColumns="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]">
+                    <p-column expander="true" styleClass="col-icon" [style]="{'width': '60px'}"></p-column>
                     <p-column selectionMode="multiple" [style]="{'width': '60px'}"></p-column>
                     <p-column field="Key" header="{{I18N.keyID['sds_block_volume_name']}}" [style]="{'width': '170px'}" >
                         <ng-template pTemplate="body" let-file="rowData" let-i="rowIndex">
@@ -37,13 +38,34 @@
                     <p-column field="size" header="Size" [style]="{'width': '120px'}"></p-column>
                     <p-column field="Location" header="Location" [style]="{'width': '120px'}" ></p-column>
                     <p-column field="Tier" header="Tier" ></p-column>
-                    <p-column field="lastModified" header="Last Modified"></p-column>
+                    <p-column field="lastModified" header="Last Modified">
+                        <ng-template pTemplate="body" let-obj="rowData" let-i="rowIndex">
+                            {{obj.lastModified ? (obj.lastModified | date:'long') : '--'}}
+                        </ng-template>
+                    </p-column>
                     <p-column header="{{I18N.keyID['sds_block_volume_operation']}}" [style]="{'width': '180px'}">
                         <ng-template pTemplate="body" let-file="rowData" let-i="rowIndex">
                             <a (click)="downloadFile(file)" *ngIf="!file.newFolder">Download</a>
                             <a [ngClass]="{'a-rep-disabled':file['disabled']}" (click)="deleteFile(file)">Delete</a>
                         </ng-template>
                     </p-column>
+                    <ng-template let-object pTemplate="rowexpansion">
+                        <p-dataTable [value]="object.Contents">
+                                <p-column field="Key" header="{{I18N.keyID['sds_block_volume_name']}}">
+                                    <ng-template pTemplate="body" let-version="rowData" let-i="rowIndex">
+                                        <span>{{version.Key}}</span> <span *ngIf="i==0" class="new-label">Latest</span>
+                                    </ng-template>
+                                </p-column>
+                                <p-column field="Location" header="Location" [style]="{'width': '120px'}" ></p-column>
+                                <p-column field="Version" header="Version" ></p-column>
+                                <p-column field="LastModified" header="Last Modified">
+                                    <ng-template pTemplate="body" let-version="rowData" let-i="rowIndex">
+                                            {{version.LastModified ? (version.LastModified | date:'long') : '--'}}
+                                    </ng-template>
+                                </p-column>
+                            </p-dataTable>
+                        
+                    </ng-template>
                 </p-dataTable>
                 <p-dialog styleClass="upload-dialog"  header="Upload" [(visible)]="uploadDisplay" [width]="600" modal="modal">
                     <div class="a-upload">

--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -261,11 +261,11 @@ export class BucketDetailComponent implements OnInit {
       }
     })
     this.allDir.forEach(it=>{
-      set.delete(it.ObjectKey);
+      set.delete(it.Contents[0].Key);
     })
     set.forEach(item=>{
       let defaultObject = lodash.cloneDeep(this.allDir[0]);
-      defaultObject.ObjectKey = item;
+      defaultObject.Contents[0].Key = item;
       this.allDir.push(defaultObject);
     })
   }
@@ -506,7 +506,7 @@ export class BucketDetailComponent implements OnInit {
                     break;
                   case "deleteMilti":
                    file.forEach(element => {
-                      let objectKey = element.ObjectKey;
+                      let objectKey = element.Contents[0].Key;
                       //If you want to delete files from a folder, you must include the name of the folder
                       if(this.folderId !=""){
                         objectKey = this.folderId + objectKey;


### PR DESCRIPTION
**Depends on [opensds/multi-cloud #779](https://github.com/opensds/multi-cloud/pull/779)**  
**Do not merge until the backend code for List versions is merged.**
Added the Bucket Versioning feature to display object versions which fixes #215 . Operations on versions will be supported in the next set of features.  

- User is now able to see the different versions of the object.  
- User is able to perform operations like `Download`, `Delete` on the latest version of the object.

Object List with Version  
![object-list-with-version](https://user-images.githubusercontent.com/19162717/70370053-9933a780-18e8-11ea-80ed-690ff9022b2d.png)

Object List with Expansion to show versions.  
![version-expanded](https://user-images.githubusercontent.com/19162717/70370060-acdf0e00-18e8-11ea-9b44-8c94c3c641da.png)

