### PR TITLE
Fixes #235. Fixed the Create Replication Dialog layout issue.

### DIFF
--- a/src/app/business/block/volumeList.html
+++ b/src/app/business/block/volumeList.html
@@ -133,7 +133,7 @@
         </p-footer>
     </p-dialog>
 <!--Create Replication-->
-<p-dialog styleClass="create-bucket-dialog" header="Create Replication" [(visible)]="createReplicationDisplay" [height]="440"  [width]="750" modal="modal">
+<p-dialog styleClass="create-replication-dialog" header="Create Replication" [(visible)]="createReplicationDisplay" [height]="440"  [width]="750" modal="modal">
     <div class="ui-grid ui-grid-responsive ui-grid-pad ui-fluid">
         <div class="ui-grid-row">
             <div class="ui-grid-col-4 item-content-backgroud">


### PR DESCRIPTION
The create replication dialog was incorrectly assigned the class for the Create Bucket dialog `.create-bucket-dialog`. The create bucket dialog has different dimensions as compared to the create replication and these changes were made to the class in the site.css file. Since the changes are not required for the create replication dialog the class has now been removed and changed to `.create-replication-dialog`. 

![fix235-create-replication-dialog](https://user-images.githubusercontent.com/19162717/70438215-57a32800-1ab3-11ea-8ea2-f9b1078b1d24.png)
