### PR TITLE
Fixes #236. Fixed the null value sent in description field in Create snapshot/acl

### DIFF
--- a/src/app/business/block/file-share-detail/file-share-detail.component.ts
+++ b/src/app/business/block/file-share-detail/file-share-detail.component.ts
@@ -251,7 +251,10 @@ export class FileShareDetailComponent implements OnInit{
     showSnapshotPropertyDialog(dialog, selectedSnapshot?){
         if(dialog == 'create'){
             this.snapshotCreateShow = true;
-            this.createSnapshotFormGroup.reset();
+            this.createSnapshotFormGroup.reset({
+                name: "",
+                description: ""
+            });
             this.getSnapshotNameCheck(this.createSnapshotFormGroup);
         }else if(dialog == 'modify'){
             this.snapshotModifyShow = true;

--- a/src/app/business/block/fileShare.component.ts
+++ b/src/app/business/block/fileShare.component.ts
@@ -163,7 +163,10 @@ export class FileShareComponent implements OnInit{
     returnSelectedFileShare(selectedFileShare, dialog){
         if(dialog == 'snapshot'){
             this.createSnapshotShow = true;
-            this.createSnapshotForm.reset();
+            this.createSnapshotForm.reset({
+                name: "",
+                description: ""
+            });
             this.checkSnapshotName = false;
             this.createSnapshotForm.get("name").valueChanges.subscribe((value: string)=>{
                 let defaultLength = "snapshot".length;
@@ -181,7 +184,12 @@ export class FileShareComponent implements OnInit{
         }else if(dialog == 'acl'){
             this.aclCreateShow = true;
             this.aclsItems = [0];
-            this.createAclsFormGroup.reset();
+            this.createAclsFormGroup.reset({
+                level : "",
+                user : "",
+                userInput0 : "",
+                description : ""
+            });
             this.getAcls(selectedFileShare);
             this.showIpErrorMessage = [false];
         }

--- a/src/app/business/block/volume-detail/snapshot-list/snapshot-list.component.ts
+++ b/src/app/business/block/volume-detail/snapshot-list/snapshot-list.component.ts
@@ -203,7 +203,11 @@ export class SnapshotListComponent implements OnInit {
 
   showSnapshotPropertyDialog(method,selectedSnapshot?){
     this.snapshotPropertyDisplay = true;
-    this.snapshotFormGroup.reset();
+    this.snapshotFormGroup.reset({
+        name: "",
+        profile : "",
+        description: ""
+    });
     if(method === 'create'){
       this.isCreate = true;
       this.isModify = false;

--- a/src/app/business/block/volumeGroup.component.ts
+++ b/src/app/business/block/volumeGroup.component.ts
@@ -101,7 +101,7 @@ export class VolumeGroupComponent implements OnInit{
         });
         this.currentGroup = volumeGroup;
         this.modifyGroupForm.controls['group_name'].setValue(this.currentGroup.name);
-        this.modifyGroupForm.controls['description'].setValue("");
+        this.modifyGroupForm.controls['description'].setValue(this.currentGroup.description);
         this.showModifyGroup = true;
     }
     submit(group){

--- a/src/app/business/block/volumeGroup.component.ts
+++ b/src/app/business/block/volumeGroup.component.ts
@@ -86,11 +86,19 @@ export class VolumeGroupComponent implements OnInit{
       }
     //show create volumes group
     createVolumeGroup(){
-        this.volumeGroupForm.reset();
+        this.volumeGroupForm.reset({
+            group_name : "",
+            description : "",
+            profile : "",
+            zone : ""
+        });
         this.showVolumeGroupDialog = true;
     }
     ModifyVolumeGroupDisplay(volumeGroup){
-        this.modifyGroupForm.reset();
+        this.modifyGroupForm.reset({
+            group_name : "",
+            description : ""
+        });
         this.currentGroup = volumeGroup;
         this.modifyGroupForm.controls['group_name'].setValue(this.currentGroup.name);
         this.modifyGroupForm.controls['description'].setValue("");

--- a/src/app/business/block/volumeList.component.ts
+++ b/src/app/business/block/volumeList.component.ts
@@ -428,7 +428,11 @@ export class VolumeListComponent implements OnInit {
 
     returnSelectedVolume(selectedVolume, dialog) {
         if (dialog === 'snapshot') {
-            this.snapshotFormGroup.reset();
+            this.snapshotFormGroup.reset({
+                name: "",
+                profile : "",
+                description: ""
+            });
             this.createSnapshotDisplay = true;
         } else if (dialog === 'replication') {
             this.createReplicationDisplay = true;


### PR DESCRIPTION
The form fields for Create Snapshot, ACL was reset everytime the dialog was displayed. In the reset method the default values are taken and since the form was not initiated the default was `null`.  
Fixed this by explicitly providing parameters to the form reset method.

![create-snapshot](https://user-images.githubusercontent.com/19162717/70441074-a227a300-1ab9-11ea-9c91-f6691926e8d4.png)
![create-snapshot-request](https://user-images.githubusercontent.com/19162717/70441079-a5bb2a00-1ab9-11ea-8754-3fa30968d8f0.png)
