### PR TITLE
Fixes #254. Fixed delete bucket fail even if bucket empty.

### DIFF
--- a/src/app/business/block/buckets.component.ts
+++ b/src/app/business/block/buckets.component.ts
@@ -533,7 +533,7 @@ export class BucketsComponent implements OnInit{
                     let str = res._body;
                     let x2js = new X2JS();
                     let jsonObj = x2js.xml_str2json(str);
-                    let alldir = jsonObj.ListBucketResult ? jsonObj.ListBucketResult :[] ;
+                    let alldir = jsonObj.ListBucketResult.Contents ? jsonObj.ListBucketResult.Contents :[] ;
                     if(alldir.length === 0){
                         this.http.get(`v1/{project_id}/plans?bucketname=${bucket.name}`).subscribe((res)=>{
                             let plans = res.json().plans ? res.json().plans : [];


### PR DESCRIPTION
Fixes #254 . The change in the object list api response structure had to be made in the buckets list page as well. When the bucket is being deleted the list objects API is called to check whether the bucket is empty. Since the API response being read was the old one the bucket was always non empty. 

Empty Bucket
![empty-bucket](https://user-images.githubusercontent.com/19162717/71087751-fa9a2700-21c2-11ea-9a2d-9459eabb8ddb.png)

Confirming delete bucket (This confirmation is visible only if the bucket is empty)
![empty-bucket-del-confirm](https://user-images.githubusercontent.com/19162717/71087761-01289e80-21c3-11ea-86af-6e4a97d6af27.png)

Bucket Deleted
![empty-bucket-deleted](https://user-images.githubusercontent.com/19162717/71087810-169dc880-21c3-11ea-9e90-c18d9d4068d6.png)


