### PR TITLE
Fixes #258. Fixed object name not visible in bucket folder.

### DIFF
--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -260,7 +260,7 @@ export class BucketDetailComponent implements OnInit {
               return folderContain;
             })
             this.allDir.forEach(val=>{
-              val.ObjectKey = val.ObjectKey.slice(this.folderId.length);
+              val.Key = val.Key.slice(this.folderId.length);
             })
           }else{
             //Distinguish between folders and files at the first level


### PR DESCRIPTION
Fixes #258. Related to #224. The key used for the name of the object was incorrect. The change in the API response had changed the key name from `ObjectKey` to `Key`. 
![bucket-folder-object](https://user-images.githubusercontent.com/19162717/71197577-ebe16c00-22b7-11ea-86ca-a9a1434bb620.png)
