### PR TITLE
[FEATURE] Fixes #215. Added display of versioned objects in a bucket.

### DIFF
--- a/src/app/business/block/bucket-detail/bucket-detail.component.html
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.html
@@ -1,3 +1,4 @@
+<p-growl [value]="msgs" [sticky]="false" [life]="6000"></p-growl>
 <div>
     <div class="custom-breadcrumb">
         <span *ngFor="let item of items; index as i">
@@ -24,31 +25,51 @@
                         <button class="" pButton type="button" (click)="getAlldir()" icon="fa-refresh"></button>
                     </div>
                 </div>
-                <p-dataTable [value]="allDir" [globalFilter]="searchByName" [(selection)]="selectedDir"  [showHeaderCheckbox]="true" resizableColumns="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]">
-                    <p-column selectionMode="multiple" [style]="{'width': '60px'}"></p-column>
-                    <p-column field="Key" header="{{I18N.keyID['sds_block_volume_name']}}" [style]="{'width': '170px'}" >
+                <p-dataTable [value]="allDir" [globalFilter]="searchByName" expandableRows="true" [(selection)]="selectedDir"  [showHeaderCheckbox]="true" resizableColumns="true" [rows]="10" [paginator]="true" [pageLinks]="3" [rowsPerPageOptions]="[10,20,50,100]">
+                    <p-column expander="true" styleClass="col-icon" [style]="{'width': '30px'}"></p-column>
+                    <p-column selectionMode="multiple" [style]="{'width': '30px'}"></p-column>
+                    <p-column field="Key" header="{{I18N.keyID['sds_block_volume_name']}}" [style]="{'width': '315px'}" >
                         <ng-template pTemplate="body" let-file="rowData" let-i="rowIndex">
                             <a *ngIf="file.newFolder" title="{{file.objectName}}" (click)="folderLink(file)">
                                 <img style="vertical-align: middle;" src="assets/business/images/volume/icon_folder.png">
-                                <span>{{file.objectName}}</span>
+                                <span>{{file.objectName}}</span> 
                             </a>
                             <a (click)="passHeaderTag()" [routerLink]="['/objectAcl/'+bucketId+'/'+file.objectName]" title="{{file.objectName}}"  *ngIf="!file.newFolder">{{file.objectName}}</a>
+                            <span class="new-label">Latest</span>
                         </ng-template>
                     </p-column>
-                    <p-column field="size" header="Size" [style]="{'width': '120px'}"></p-column>
+                    <p-column field="size" header="Size" [style]="{'width': '75px'}"></p-column>
                     <p-column field="Location" header="Location" [style]="{'width': '120px'}" ></p-column>
-                    <p-column field="Tier" header="Tier" ></p-column>
-                    <p-column field="lastModified" header="Last Modified">
+                    <p-column field="Tier" header="Tier" [style]="{'width': '210px'}"></p-column>
+                    <p-column field="lastModified" header="Last Modified" [style]="{'width': '240px'}">
                         <ng-template pTemplate="body" let-obj="rowData" let-i="rowIndex">
                             {{obj.lastModified ? (obj.lastModified | date:'long') : '--'}}
                         </ng-template>
                     </p-column>
-                    <p-column header="{{I18N.keyID['sds_block_volume_operation']}}" [style]="{'width': '180px'}">
+                    <p-column header="{{I18N.keyID['sds_block_volume_operation']}}" [style]="{'width': '160px'}">
                         <ng-template pTemplate="body" let-file="rowData" let-i="rowIndex">
                             <a (click)="downloadFile(file)" *ngIf="!file.newFolder">Download</a>
                             <a [ngClass]="{'a-rep-disabled':file['disabled']}" (click)="deleteFile(file)">Delete</a>
                         </ng-template>
                     </p-column>
+                    <ng-template let-object pTemplate="rowexpansion">
+                        <p-dataTable [value]="object.Versions" [rows]="10" [paginator]="true" [pageLinks]="3">
+                                <p-column field="Key" header="{{I18N.keyID['sds_block_volume_name']}}">
+                                    <ng-template pTemplate="body" let-version="rowData" let-i="rowIndex">
+                                        <span>{{version.Key}}</span> 
+                                    </ng-template>
+                                </p-column>
+                                <p-column field="size" header="Size" [style]="{'width': '120px'}"></p-column>
+                                <p-column field="Location" header="Location" [style]="{'width': '120px'}" ></p-column>
+                                <p-column field="Version" header="Version" ></p-column>
+                                <p-column field="LastModified" header="Last Modified">
+                                    <ng-template pTemplate="body" let-version="rowData" let-i="rowIndex">
+                                            {{version.LastModified ? (version.LastModified | date:'long') : '--'}}
+                                    </ng-template>
+                                </p-column>
+                            </p-dataTable>
+                        
+                    </ng-template>
                 </p-dataTable>
                 <p-dialog styleClass="upload-dialog"  header="Upload" [(visible)]="uploadDisplay" [width]="600" modal="modal">
                     <div class="a-upload">

--- a/src/app/business/block/bucket-detail/bucket-detail.component.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.component.ts
@@ -466,9 +466,9 @@ export class BucketDetailComponent implements OnInit {
   downloadFile(file) {
     let fileObjectKey;
     if(this.folderId !=""){
-      fileObjectKey = this.folderId + file.Contents[0].Key;
+      fileObjectKey = this.folderId + file.Contents[0].Key + '?versionId=' + file.Contents[0].Version;
     }else{
-      fileObjectKey = file.Contents[0].Key;
+      fileObjectKey = file.Contents[0].Key + '?versionId=' + file.Contents[0].Version;
     }
     let downloadUrl = `${this.BucketService.url}/${this.bucketId}/${fileObjectKey}`;
     window['getAkSkList'](()=>{
@@ -591,7 +591,7 @@ export class BucketDetailComponent implements OnInit {
               try {
                 switch(func){
                   case "delete":
-                    let objectKey = file.Contents[0].Key;
+                    let objectKey = file.Contents[0].Key + '?versionId=' + file.Contents[0].Version;
                     //If you want to delete files from a folder, you must include the name of the folder
                     if(this.folderId !=""){
                       objectKey = this.folderId + objectKey;
@@ -615,7 +615,7 @@ export class BucketDetailComponent implements OnInit {
                     break;
                   case "deleteMilti":
                    file.forEach(element => {
-                      let objectKey = element.Contents[0].Key;
+                      let objectKey = element.Contents[0].Key + '?versionId=' + file.Contents[0].Version;
                       //If you want to delete files from a folder, you must include the name of the folder
                       if(this.folderId !=""){
                         objectKey = this.folderId + objectKey;

--- a/src/app/business/block/bucket-detail/bucket-detail.module.ts
+++ b/src/app/business/block/bucket-detail/bucket-detail.module.ts
@@ -6,7 +6,7 @@ import { BucketDetailComponent } from './bucket-detail.component';
 import { LifeCycleModule } from './lifeCycle/lifeCycle.module';
 import { AclModule } from './acl/acl.module';
 import { TabViewModule,ButtonModule, DataTableModule, DropMenuModule, DialogModule, FormModule, InputTextModule, InputTextareaModule, 
-  ConfirmDialogModule ,ConfirmationService,CheckboxModule,DropdownModule, SplitButtonModule} from './../../../components/common/api';
+  ConfirmDialogModule ,ConfirmationService,CheckboxModule,DropdownModule, SplitButtonModule, GrowlModule} from './../../../components/common/api';
 import { HttpService } from './../../../shared/service/Http.service';
 import { BucketService } from '../buckets.service';
 import { HttpClientModule } from '@angular/common/http';
@@ -35,6 +35,7 @@ let routers = [{
     LifeCycleModule,
     HttpClientModule,
     SplitButtonModule,
+    GrowlModule,
     AclModule,
   ],
   declarations: [

--- a/src/assets/business/css/site.scss
+++ b/src/assets/business/css/site.scss
@@ -2062,3 +2062,13 @@ a.remove-initiator {
 .input-context-help {
     padding-top: 0.1rem;
 }
+
+span.new-label {
+    border: 1px solid #009e4e;
+    padding: 0.15em 0.50em;
+    margin-left: 0.3rem;
+    color: #ffffff;
+    background-color: #009e4e;
+    border-radius: 3px;
+    font-weight: 600;
+}


### PR DESCRIPTION
**Do not merge until the backend code for List versions is merged.**
**Depends on [opensds/multi-cloud #853](https://github.com/opensds/multi-cloud/pull/853)**  

Added the Object Versioning feature to display object versions in a bucket which fixes #215 . Operations on versions will be supported in the next set of features.  
- User is now able to see the latest version of the object at the top level with the `latest` label.  
- User is now able to see the different versions of the object after expanding the table row.  
- User is able to perform operations like `Download`, `Delete` on the latest version of the object.

Object List with Version  
![obj-with-versions](https://user-images.githubusercontent.com/19162717/71776632-e889f800-2fba-11ea-9935-cfbacf0b86bd.png)

Object List with Expansion to show versions.  
![obj-with-versions-expanded](https://user-images.githubusercontent.com/19162717/71776633-ee7fd900-2fba-11ea-91f7-31e997a85ddc.png)

